### PR TITLE
tlog: Various fixes

### DIFF
--- a/tlog/api/v1/api.go
+++ b/tlog/api/v1/api.go
@@ -133,7 +133,7 @@ type RecordNewReply struct {
 	Tree        trillian.Tree          `json:"tree"`        // TreeId is the record id
 	InitialRoot trillian.SignedLogRoot `json:"initialroot"` // Tree creation root
 	STH         trillian.SignedLogRoot `json:"sth"`         // Signed tree head after record addition
-	Proofs      []QueuedLeafProof      `json"proofs"`       // Queued leaves and their proofs
+	Proofs      []QueuedLeafProof      `json:"proofs"`      // Queued leaves and their proofs
 }
 
 // RecordAppend adds new record entries to a record.  The server will not
@@ -150,8 +150,8 @@ type RecordAppend struct {
 // that were append to a record. It returns trillian types so that the client
 // can perform verifications.
 type RecordAppendReply struct {
-	STH    trillian.SignedLogRoot `json:"sth"`   // Signed tree head after record addition
-	Proofs []QueuedLeafProof      `json"proofs"` // Queued leaves and their proofs
+	STH    trillian.SignedLogRoot `json:"sth"`    // Signed tree head after record addition
+	Proofs []QueuedLeafProof      `json:"proofs"` // Queued leaves and their proofs
 }
 
 // RecordGet retrieves the entire record including proofs. This is an expensive


### PR DESCRIPTION
This diff addresses:
* tclient printing
* fsck tree coherency test
* having tclient validate the anchor data for record entries
* returning user errors from tserver when appropriate

I've been looking into decred/politeia#949 and I'm pretty sure it's a bug in dcrtime.  Will need to investigate further.

Once this diff is merged I think decred/politeia#951 is ready to be merged into master.